### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/date-logic": "5.0.1",
-  "packages/date-renderer": "1.8.0"
+  "packages/date-logic": "5.0.2",
+  "packages/date-renderer": "1.8.1"
 }

--- a/packages/date-logic/CHANGELOG.md
+++ b/packages/date-logic/CHANGELOG.md
@@ -19,6 +19,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
+## [5.0.2](https://github.com/aversini/monorepo/compare/date-logic-v5.0.1...date-logic-v5.0.2) (2024-09-14)
+
+
+### Bug Fixes
+
+* **date-logic:** actually no french it is ([769ebde](https://github.com/aversini/monorepo/commit/769ebded3e74f42381b50cc28c819dbee24b4b20))
+
 ## [5.0.1](https://github.com/aversini/monorepo/compare/date-logic-v5.0.0...date-logic-v5.0.1) (2024-09-14)
 
 

--- a/packages/date-logic/package.json
+++ b/packages/date-logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@versini/date-logic",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/date-renderer/CHANGELOG.md
+++ b/packages/date-renderer/CHANGELOG.md
@@ -14,6 +14,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
+## [1.8.1](https://github.com/aversini/monorepo/compare/date-renderer-v1.8.0...date-renderer-v1.8.1) (2024-09-14)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/date-logic bumped to 5.0.2
+
 ## [1.8.0](https://github.com/aversini/monorepo/compare/date-renderer-v1.7.0...date-renderer-v1.8.0) (2024-09-14)
 
 

--- a/packages/date-renderer/package.json
+++ b/packages/date-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@versini/date-renderer",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>date-logic: 5.0.2</summary>

## [5.0.2](https://github.com/aversini/monorepo/compare/date-logic-v5.0.1...date-logic-v5.0.2) (2024-09-14)


### Bug Fixes

* **date-logic:** actually no french it is ([769ebde](https://github.com/aversini/monorepo/commit/769ebded3e74f42381b50cc28c819dbee24b4b20))
</details>

<details><summary>date-renderer: 1.8.1</summary>

## [1.8.1](https://github.com/aversini/monorepo/compare/date-renderer-v1.8.0...date-renderer-v1.8.1) (2024-09-14)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/date-logic bumped to 5.0.2
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).